### PR TITLE
Remove global changes to log.flags

### DIFF
--- a/adjacency/adjcmartix.go
+++ b/adjacency/adjcmartix.go
@@ -16,7 +16,6 @@ type AdjacencyGraph struct {
 var AdjacencyGph = make(map[string]AdjacencyGraph)
 
 func init() {
-	log.SetFlags(log.Lshortfile)
 	AdjacencyGph["qwerty"] = BuildQwerty()
 	AdjacencyGph["dvorak"] = BuildDvorak()
 	AdjacencyGph["keypad"] = BuildKeypad()


### PR DESCRIPTION
log.SetFlags will overwrite the default log flags (i.e. date+time) for anyone who imports this library. I couldn't tell how important it was for you to log the filename – if it was just for some previous debugging, you should be able to remove it; if it's still needed, then I can create a package-wide logger with these flags. Just let me know one way or the other.

Thanks for the package!