### PR TITLE
Filtering the matchers

### DIFF
--- a/match/match.go
+++ b/match/match.go
@@ -33,3 +33,8 @@ type DateMatch struct {
 	Separator        string
 	Day, Month, Year int64
 }
+
+type Matcher struct {
+	MatchingFunc func(password string) []Match
+	ID           string
+}

--- a/matching/dateMatchers.go
+++ b/matching/dateMatchers.go
@@ -1,12 +1,26 @@
 package matching
 
 import (
-	"github.com/nbutton23/zxcvbn-go/entropy"
-	"github.com/nbutton23/zxcvbn-go/match"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/nbutton23/zxcvbn-go/entropy"
+	"github.com/nbutton23/zxcvbn-go/match"
 )
+
+const (
+	DATESEP_MATCHER_NAME        = "DATESEP"
+	DATEWITHOUTSEP_MATCHER_NAME = "DATEWITHOUT"
+)
+
+func FilterDateSepMatcher(m match.Matcher) bool {
+	return m.ID == DATESEP_MATCHER_NAME
+}
+
+func FilterDateWithoutSepMatcher(m match.Matcher) bool {
+	return m.ID == DATEWITHOUTSEP_MATCHER_NAME
+}
 
 func checkDate(day, month, year int64) (bool, int64, int64, int64) {
 	if (12 <= month && month <= 31) && day <= 12 {
@@ -23,6 +37,7 @@ func checkDate(day, month, year int64) (bool, int64, int64, int64) {
 
 	return true, day, month, year
 }
+
 func dateSepMatcher(password string) []match.Match {
 	dateMatches := dateSepMatchHelper(password)
 

--- a/matching/leet.go
+++ b/matching/leet.go
@@ -1,10 +1,17 @@
 package matching
 
 import (
+	"strings"
+
 	"github.com/nbutton23/zxcvbn-go/entropy"
 	"github.com/nbutton23/zxcvbn-go/match"
-	"strings"
 )
+
+const L33T_MATCHER_NAME = "l33t"
+
+func FilterL33tMatcher(m match.Matcher) bool {
+	return m.ID == L33T_MATCHER_NAME
+}
 
 func l33tMatch(password string) []match.Match {
 
@@ -16,7 +23,7 @@ func l33tMatch(password string) []match.Match {
 
 	for _, permutation := range permutations {
 		for _, mather := range DICTIONARY_MATCHERS {
-			matches = append(matches, mather(permutation)...)
+			matches = append(matches, mather.MatchingFunc(permutation)...)
 		}
 	}
 

--- a/matching/matching.go
+++ b/matching/matching.go
@@ -1,15 +1,16 @@
 package matching
 
 import (
+	"sort"
+
 	"github.com/nbutton23/zxcvbn-go/adjacency"
 	"github.com/nbutton23/zxcvbn-go/frequency"
 	"github.com/nbutton23/zxcvbn-go/match"
-	"sort"
 )
 
 var (
-	DICTIONARY_MATCHERS []func(password string) []match.Match
-	MATCHERS            []func(password string) []match.Match
+	DICTIONARY_MATCHERS []match.Matcher
+	MATCHERS            []match.Matcher
 	ADJACENCY_GRAPHS    []adjacency.AdjacencyGraph
 	L33T_TABLE          adjacency.AdjacencyGraph
 
@@ -26,7 +27,7 @@ func init() {
 	loadFrequencyList()
 }
 
-func Omnimatch(password string, userInputs []string) (matches []match.Match) {
+func Omnimatch(password string, userInputs []string, filters ...func(match.Matcher) bool) (matches []match.Match) {
 
 	//Can I run into the issue where nil is not equal to nil?
 	if DICTIONARY_MATCHERS == nil || ADJACENCY_GRAPHS == nil {
@@ -39,7 +40,12 @@ func Omnimatch(password string, userInputs []string) (matches []match.Match) {
 	}
 
 	for _, matcher := range MATCHERS {
-		matches = append(matches, matcher(password)...)
+		for i := range filters {
+			if filters[i](matcher) {
+				continue
+			}
+		}
+		matches = append(matches, matcher.MatchingFunc(password)...)
 	}
 	sort.Sort(match.Matches(matches))
 	return matches
@@ -48,7 +54,7 @@ func Omnimatch(password string, userInputs []string) (matches []match.Match) {
 func loadFrequencyList() {
 
 	for n, list := range frequency.FrequencyLists {
-		DICTIONARY_MATCHERS = append(DICTIONARY_MATCHERS, buildDictMatcher(n, buildRankedDict(list.List)))
+		DICTIONARY_MATCHERS = append(DICTIONARY_MATCHERS, match.Matcher{MatchingFunc: buildDictMatcher(n, buildRankedDict(list.List)), ID: n})
 	}
 
 	L33T_TABLE = adjacency.AdjacencyGph["l33t"]
@@ -67,11 +73,11 @@ func loadFrequencyList() {
 	SEQUENCES["digits"] = "0123456789"
 
 	MATCHERS = append(MATCHERS, DICTIONARY_MATCHERS...)
-	MATCHERS = append(MATCHERS, spatialMatch)
-	MATCHERS = append(MATCHERS, repeatMatch)
-	MATCHERS = append(MATCHERS, sequenceMatch)
-	MATCHERS = append(MATCHERS, l33tMatch)
-	MATCHERS = append(MATCHERS, dateSepMatcher)
-	MATCHERS = append(MATCHERS, dateWithoutSepMatch)
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: spatialMatch, ID: SPATIAL_MATCHER_NAME})
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: repeatMatch, ID: REPEAT_MATCHER_NAME})
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: sequenceMatch, ID: SEQUENCE_MATCHER_NAME})
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: l33tMatch, ID: L33T_MATCHER_NAME})
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: dateSepMatcher, ID: DATESEP_MATCHER_NAME})
+	MATCHERS = append(MATCHERS, match.Matcher{MatchingFunc: dateWithoutSepMatch, ID: DATEWITHOUTSEP_MATCHER_NAME})
 
 }

--- a/matching/matching.go
+++ b/matching/matching.go
@@ -40,12 +40,16 @@ func Omnimatch(password string, userInputs []string, filters ...func(match.Match
 	}
 
 	for _, matcher := range MATCHERS {
+		shouldBeFiltered := false
 		for i := range filters {
 			if filters[i](matcher) {
-				continue
+				shouldBeFiltered = true
+				break
 			}
 		}
-		matches = append(matches, matcher.MatchingFunc(password)...)
+		if !shouldBeFiltered {
+			matches = append(matches, matcher.MatchingFunc(password)...)
+		}
 	}
 	sort.Sort(match.Matches(matches))
 	return matches

--- a/matching/repeatMatch.go
+++ b/matching/repeatMatch.go
@@ -1,10 +1,17 @@
 package matching
 
 import (
+	"strings"
+
 	"github.com/nbutton23/zxcvbn-go/entropy"
 	"github.com/nbutton23/zxcvbn-go/match"
-	"strings"
 )
+
+const REPEAT_MATCHER_NAME = "REPEAT"
+
+func FilterRepeatMatcher(m match.Matcher) bool {
+	return m.ID == REPEAT_MATCHER_NAME
+}
 
 func repeatMatch(password string) []match.Match {
 	var matches []match.Match

--- a/matching/sequenceMatch.go
+++ b/matching/sequenceMatch.go
@@ -1,10 +1,17 @@
 package matching
 
 import (
+	"strings"
+
 	"github.com/nbutton23/zxcvbn-go/entropy"
 	"github.com/nbutton23/zxcvbn-go/match"
-	"strings"
 )
+
+const SEQUENCE_MATCHER_NAME = "SEQ"
+
+func FilterSequenceMatcher(m match.Matcher) bool {
+	return m.ID == SEQUENCE_MATCHER_NAME
+}
 
 func sequenceMatch(password string) []match.Match {
 	var matches []match.Match

--- a/matching/spatialMatch.go
+++ b/matching/spatialMatch.go
@@ -1,11 +1,18 @@
 package matching
 
 import (
+	"strings"
+
 	"github.com/nbutton23/zxcvbn-go/adjacency"
 	"github.com/nbutton23/zxcvbn-go/entropy"
 	"github.com/nbutton23/zxcvbn-go/match"
-	"strings"
 )
+
+const SPATIAL_MATCHER_NAME = "SPATIAL"
+
+func FilterSpatialMatcher(m match.Matcher) bool {
+	return m.ID == SPATIAL_MATCHER_NAME
+}
 
 func spatialMatch(password string) (matches []match.Match) {
 	for _, graph := range ADJACENCY_GRAPHS {

--- a/zxcvbn.go
+++ b/zxcvbn.go
@@ -3,7 +3,7 @@ package zxcvbn
 import (
 	"time"
 
-	"github.com/TheMacies/zxcvbn-go/match"
+	"github.com/nbutton23/zxcvbn-go/match"
 	"github.com/nbutton23/zxcvbn-go/matching"
 	"github.com/nbutton23/zxcvbn-go/scoring"
 	"github.com/nbutton23/zxcvbn-go/utils/math"

--- a/zxcvbn.go
+++ b/zxcvbn.go
@@ -1,15 +1,17 @@
 package zxcvbn
 
 import (
+	"time"
+
+	"github.com/TheMacies/zxcvbn-go/match"
 	"github.com/nbutton23/zxcvbn-go/matching"
 	"github.com/nbutton23/zxcvbn-go/scoring"
 	"github.com/nbutton23/zxcvbn-go/utils/math"
-	"time"
 )
 
-func PasswordStrength(password string, userInputs []string) scoring.MinEntropyMatch {
+func PasswordStrength(password string, userInputs []string, filters ...func(match.Matcher) bool) scoring.MinEntropyMatch {
 	start := time.Now()
-	matches := matching.Omnimatch(password, userInputs)
+	matches := matching.Omnimatch(password, userInputs, filters...)
 	result := scoring.MinimumEntropyMatchSequence(password, matches)
 	end := time.Now()
 


### PR DESCRIPTION
L33t matcher has some corner case issues that result in huge RAM and CPU usage.
I removed the l33t matcher and suddenly our microservice became much more resource-friendly. 
However, instead of commenting the code I propose a way to filter out unwanted matchers .
Goal of my change was to stay 100% backwards compatible so that updating vendor will not change how the library works at all .
Here comes a chart of RAM usage of our microservice using this library . The huge change in resource usage happened right after I turned off l33t matcher. 

![memory_passwords](https://user-images.githubusercontent.com/9625503/32329033-10c802d6-bfdc-11e7-8396-8122d0506b64.png)

My code now looks like that :
`zxcvbn.PasswordStrength(password, inputs, matching.FilterL33tMatcher)`

