### PR TITLE
Use bigint Binomial for Choose function

### DIFF
--- a/utils/math/mathutils.go
+++ b/utils/math/mathutils.go
@@ -1,26 +1,22 @@
 package zxcvbn_math
 
-import "math"
+import (
+	"math"
+	"math/big"
+)
 
-/**
-I am surprised that I have to define these. . . Maybe i just didn't look hard enough for a lib.
-*/
-
-//http://blog.plover.com/math/choose.html
+// NChoseK returns the binomial co-efficient taking and returning float64
+// It is simply a type adjusting wrapper for big.Binomial()
 func NChoseK(n, k float64) float64 {
 	if k > n {
 		return 0
 	} else if k == 0 {
 		return 1
 	}
+	coef := new(big.Int).Binomial(int64(n), int64(k))
 
-	var r float64 = 1
-
-	for d := float64(1); d <= k; d++ {
-		r *= n
-		r /= d
-		n--
-	}
+	f := new(big.Float).SetInt(coef)
+	r, _ := f.Float64()
 
 	return r
 }


### PR DESCRIPTION
A comment in the original said,

> I am surprised that I have to define these. . . Maybe i just didn't look hard enough for a lib.

The choose function is also known as the binomial coefficient, and this exists in math/big for Ints.

## What

This PR replaces the contents of `NChoseK()` with a call to math/big's `Binomial()`. It does some conversions so that no changes need to be made in how NChoseK is called.

## Why?

Why make this change?

1. Mostly because I saw the comment quoted above
2. The particular implementation in the original is inefficient for large numbers. Binomial coeffients are better implemented using the log gamma function instead of calculating factorials the slow way. Though perhaps using a big integer library loose some of that.
3. It may be cleaner to use integer arguments instead of float64 at this point, and this change now will make that easier to do sometime in the future.

## What this doesn't do

1. It doesn't correct the spelling of "NChoseK" (which should be "NChooseK". "Choose" is a really strange word and tempting to misspell). I wanted to make a small change, only touching the one function.
2. It does not adjust the calling code to make use of integers. I do not understand why float64 is used so much in this package, and so it would be silly for me to tinker with that before understanding the reasons for the current choices.

## Possible objections

1. The move to using big Ints may be a performance hit. (I don't think it will be, but I have not benchmarked the two on the sorts of numbers used.
2. It requires yet another import: math/big

Although I do acknowledge those as legitimate objections, I wouldn't be submitting this PR if I didn't think the benefits outweigh them.



