### PR TITLE
Return correct seconds to years conversion in scoring.go

### DIFF
--- a/scoring/scoring.go
+++ b/scoring/scoring.go
@@ -156,7 +156,7 @@ func displayTime(seconds float64) string {
 	} else if seconds < year {
 		return fmt.Sprintf(formater, (1 + math.Ceil(seconds/month)), "months")
 	} else if seconds < century {
-		return fmt.Sprintf(formater, (1 + math.Ceil(seconds/century)), "years")
+		return fmt.Sprintf(formater, (math.Ceil((seconds / century) * 100)), "years")
 	} else {
 		return "centuries"
 	}


### PR DESCRIPTION
There is a logic error in the crack time conversion to "CrackTimeDisplay" for values that would reflect in years. For example, a value of "2037200406.475" seconds crack time would currently be displayed as "2.0" years, while the actual time would convert to "64.56 years".

This patch fixes the scoring.go's displayTime() function, so that for the above mentioned time, it would report "64.0" years